### PR TITLE
Fix failure to build pv on Solaris derivative systems

### DIFF
--- a/autoconf/header.in
+++ b/autoconf/header.in
@@ -71,6 +71,7 @@
 #   define fstat64 fstat
 #   define lstat64 lstat
 #  endif
+# elif (defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__))
 # else
 #  define stat64 stat
 #  define fstat64 fstat


### PR DESCRIPTION
I don't know if there is any interest in this... I had a problem with building on `OmniOS` and `SmartOS` and this patch solves that problem. I am quite confident same problem exists on many __illumos__-based systems, and probably with Solaris 11 as well, though I did not test with 11 honestly.